### PR TITLE
LIBASPACE-163. Tweaked README.md and docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,23 @@ UMD ArchivesSpace Docker
 
 ## Quick Start
 
-```
-git clone git@github.com:umd-lib/aspace-docker.git
-cd aspace-docker
-docker-compose up
-```
+### Prerequisites
 
-### Local Hosts
+The following need to be setup once on the Docker host machine.
+
+#### Local Hosts
 
 To access the web interfaces for the staff and public interfaces, you will need
 to add `aspace.local` and `archives.local` as aliases for `localhost` to your
-`/etc/hosts` file. Then, you will be able to access the web interfaces via the
-following URLs:
+`/etc/hosts` file, i.e.:
 
-* Staff: <https://aspace.local/>
-* Public: <https://archives.local/>
+```
+127.0.0.1       localhost aspace.local archives.local
+```
 
-### File Sharing
+#### File Sharing
 
-Docker will need to be configured to have access to the `aspace-docker` directory
+Docker may need to be configured to access the `aspace-docker` directory
 on your host machine. On Mac OS X:
 
 1. Open the Docker Desktop **Preferences**
@@ -31,22 +29,61 @@ on your host machine. On Mac OS X:
 4. Navigate to the `aspace-docker` directory and click **Open**
 5. Click **Apply & Restart**
 
+**Note:** Docker file sharing allows access to any subdirectory (of any depth)
+of any directory that is shared. So if Docker is already configured to share
+a directory that contains the `aspace-docker` directory, it is not necessary
+to share it again.
+
+### Running aspace-docker
+
+```
+git clone git@github.com:umd-lib/aspace-docker.git
+cd aspace-docker
+docker-compose up
+```
+
+## URLs/Ports
+
+* <https://archives.local/> - ArchivesSpace Public User Interface (PUI)
+* <https://aspace.local/> - ArchivesSpace Staff Interface
+* <http://localhost:8983/> - Solr instance
+
+A MySQL client (such as MySQL Workbench) can connect to the database on
+port 3306.
+
 ## ArchivesSpace Plugins
 
 These are listed in the [plugins](archivesspace/config/plugins) config file.
 
+## Docker Volumes
+
+The MySQL data is stored in a Docker volume, so stopping the Docker containers
+won't destroy the data. If the Docker containers are restarted (using
+"docker-compose up"), the existing Solr and MySQL data will be preserved.
+
+If the Docker containers are removed, then the Docker volumes should also
+removed, as when the containers are rebuilt, the Solr container will not have
+any data, but the MySQL database will.
+
+To delete the Docker volumes:
+
+```
+docker volume rm aspace-docker_aspace aspace-docker_mysql
+```
+
 ## Details
 
-This uses Docker Compose to deploy the application. 
+This uses Docker Compose to deploy the application.
 Included in the docker-compose.yml configuration file, there are container
 definitions for:
 
 * ArchivesSpace
 * Nginx (SSL reverse proxy)
 * MySQL
-* Solr 
+* Solr
 
-The ArchivesSpace container can also be configured to use a different database (external MySQL or embedded Derby DB), and a different Solr (external Solr or
+The ArchivesSpace container can also be configured to use a different database
+(external MySQL or embedded Derby DB), and a different Solr (external Solr or
 internal). The relevant settings in the docker-compose.yml file are:
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   app:
     build:
       context: ./archivesspace
-    image: docker.lib.umd.edu/aspace/aspace_app 
+    image: docker.lib.umd.edu/aspace/aspace_app
     ports:
       - "8080:8080"
       - "8081:8081"
@@ -18,14 +18,14 @@ services:
       APPCONFIG_FRONTEND_PROXY_URL: 'https://aspace.local'
       APPCONFIG_PUBLIC_PROXY_URL: 'https://archives.local'
     volumes:
-        - aspace:/opt/archivesspace/data 
+        - aspace:/opt/archivesspace/data
   db:
     image: mysql:5.7
     command: --character-set-server=utf8 --collation-server=utf8_unicode_ci --innodb_buffer_pool_size=2G --innodb_buffer_pool_instances=2
     ports:
       - "3306:3306"
     volumes:
-      - mysql:/var/lib/mysql 
+      - mysql:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: "123456"
       MYSQL_DATABASE: archivesspace
@@ -42,10 +42,10 @@ services:
     environment:
       ASPACE_STAFF: aspace.local
       ASPACE_PUBLIC: archives.local
-    volumes: 
+    volumes:
       - ./proxy/aspace.template:/etc/nginx/conf.d/aspace.template
       - ./proxy/includes:/etc/nginx/includes
-      - ./proxy/docker-startup.sh:/startup.sh 
+      - ./proxy/docker-startup.sh:/startup.sh
       - ./ssl/certs:/etc/ssl/certs
     ports:
       - "80:80"
@@ -56,4 +56,4 @@ services:
 volumes:
   mysql:
   aspace:
-  plugins:
+


### PR DESCRIPTION
Reorganized "README.md" file to include a "Prerequisites" section, as
well as adding information about Docker volume use, and a list of URLs
and ports.

In "docker-compose.yml" removed the "plugins" volume, as it is not
needed.

https://issues.umd.edu/browse/LIBASPACE-163