### PR TITLE
LIBASPACE-239. Update aspace-umd-lib-handle-service plugin version.

### DIFF
--- a/archivesspace/config/plugins
+++ b/archivesspace/config/plugins
@@ -1,6 +1,6 @@
 # THESE ARE THE VERSIONS OF PLUGINS
 # URL VERSION [NAME]
-https://github.com/umd-lib/umd-lib-aspace-theme.git release/1.3.0
+https://github.com/umd-lib/umd-lib-aspace-theme.git 1.3.0
 https://github.com/lyrasis/aspace-oauth.git dd4ac72f8fbedf612a52b58feeeb5ddbc078fc9d
 https://github.com/hudmol/payments_module.git 5fddd44caf2002ba34578e1eead7fb9efb83cdee 
 https://github.com/umd-lib/aspace_yale_accessions.git 1.1-umd-0.3 
@@ -10,6 +10,6 @@ https://github.com/hudmol/default_text_for_notes.git 383ec7517bb016a69b118c17517
 https://github.com/hudmol/and_search.git v0.1 
 https://github.com/hudmol/digitization_work_order.git v1.4
 https://github.com/AtlasSystems/ArchivesSpace-Aeon-Fulfillment-Plugin.git 20180726 aeon_fulfillment
-https://github.com/umd-lib/aspace-umd-lib-handle-service 59de59cea4f02243abb0053b37a389e9fcca6a20
-https://github.com/umd-lib/umd_aeon_fulfillment.git release/1.0.0
+https://github.com/umd-lib/aspace-umd-lib-handle-service 1.1.0
+https://github.com/umd-lib/umd_aeon_fulfillment.git 1.0.0
 https://github.com/harvard-library/aspace-import-excel.git v2.1.15


### PR DESCRIPTION
Also updated other plugins from release branches to tags.

https://issues.umd.edu/browse/LIBASPACE-239